### PR TITLE
Throw exception if TLS desired but not working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *~
+.idea
 .settings
 .buildpath
 LdapBundle/Resources/config/ldapcredentials.yml
+*.iml

--- a/LdapBundle/Security/Ldap/Ldap.php
+++ b/LdapBundle/Security/Ldap/Ldap.php
@@ -286,7 +286,8 @@ class Ldap implements LdapInterface
             ldap_set_option($this->connection, LDAP_OPT_REFERRALS, $this->getOptReferrals());
             
             if ($this->getUseStartTls()) {
-                ldap_start_tls($this->connection);
+                $tlsResult = ldap_start_tls($this->connection);
+                if (!$tlsResult) throw new ConnectionException('TLS initialization failed!');
             }
             
             if ($this->enableAdmin) {


### PR DESCRIPTION
I think an error starting TLS should raise an exception to ensure an encrypted connection.
